### PR TITLE
Remove extraneous spaces from _oasis

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -82,7 +82,7 @@ Library lenses
     boomerang
   Modules:
     Prelude
-   
+
 Executable boomerang
   Path: boomerang
   MainIs: boomerang.ml


### PR DESCRIPTION
Running `make` using oasis 0.4.7 resulted in

``````
$ make
oasis setup
E: file "_oasis", line 85, characters 0-4: extraneous blanks at the beginning of the line
make: *** [setup.ml] Error 1```
``````
